### PR TITLE
Add templating for new presentations

### DIFF
--- a/remark-latest.min.js
+++ b/remark-latest.min.js
@@ -1,0 +1,1 @@
+./byo-web-token/mdoc/remark-latest.min.js

--- a/scripts/new-presentation
+++ b/scripts/new-presentation
@@ -1,0 +1,158 @@
+#!/bin/bash
+
+set -e
+
+title=$1
+titleSlug=$(echo "${title}" | sed 's/ /-/g' | sed -e 's/\(.*\)/\L\1/')
+
+git checkout -b "pres/js/${titleSlug}"
+
+indexHtml=$(cat <<- EOF
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>$1</title>
+  <meta charset="utf-8">
+  <style>
+    @import url(https://fonts.googleapis.com/css?family=Yanone+Kaffeesatz);
+    @import url(https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic);
+    @import url(https://fonts.googleapis.com/css?family=Ubuntu+Mono:400,700,400italic);
+
+    body {
+      font-family: 'Droid Serif', 'Helvetica';
+      /*line-height: 1.25em;*/
+    }
+
+    li {
+      margin: 10px 0;
+    }
+
+    h1,
+    h2,
+    h3 {
+      font-family: 'Yanone Kaffeesatz', 'Gill Sans';
+      font-weight: normal;
+    }
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+    }
+
+    .remark-code,
+    .remark-inline-code {
+      font-family: 'Ubuntu Mono', 'Consolas', 'Courier New';
+    }
+  </style>
+</head>
+
+<body>
+  <textarea id="source">
+
+class: center, middle
+
+# $1
+James Santucci • \`@jisantuc\`
+
+@47Degrees / @jisantuc
+
+???
+
+Questions at the end
+
+---
+
+class: center, middle
+
+# A section title slide
+
+---
+
+## A normal slide
+
+---
+
+## A slide with evaluated code
+
+- point to a whole new database that lives somewhere else
+
+\`\`\`scala mdoc
+// treat these as newtypes for non-empty strings
+type DatabaseUser = String
+type DatabaseHost = String
+type DatabasePassword = String
+
+case class DatabaseConfig(
+  dbUser: DatabaseUser,
+  dbHost: DatabaseHost,
+  dbPassword: DatabasePassword
+)
+\`\`\`
+
+---
+
+## A slide with evaluated code with no output
+
+- command line args are similar to env variables
+
+\`\`\`scala mdoc:silent
+val serverOpt = "abcde"
+\`\`\`
+
+---
+
+## A slide with evaluated code that is invisible in the presentation
+
+\`\`\`scala mdoc:invisible
+val passwordlessOpt = "abcde"
+\`\`\`
+
+---
+
+class: center, middle
+
+# Thanks!
+
+Code and slides at \`jisantuc/mdoc-presentations\` on GitHub
+
+## Questions?
+
+ </textarea>
+  <script src="remark-latest.min.js">
+  </script>
+  <script>
+    var slideshow = remark.create();
+  </script>
+</body>
+
+</html>
+EOF
+)
+
+projectConfig=$(cat <<- EOF
+
+lazy val \`$titleSlug\` = project
+  .in(file("$titleSlug"))
+  .settings(moduleName := "$titleSlug")
+  .settings(baseSettings: _*)
+  .settings(mdocModule: _*)
+  .settings(
+    libraryDependencies ++= Seq()
+  )
+  .enablePlugins(MdocPlugin)
+EOF
+)
+
+mkdir -p "${titleSlug}/mdoc"
+mkdir -p "${titleSlug}/docs"
+
+echo "${indexHtml}" > "${titleSlug}/mdoc/index.html"
+cp $(readlink ./remark-latest.min.js) "${titleSlug}/mdoc/"
+echo "${projectConfig}" >> build.sbt
+
+sbt "${titleSlug}/mdoc"
+
+git add "${titleSlug}"
+git commit -m "${title}, first commit"

--- a/scripts/new-presentation
+++ b/scripts/new-presentation
@@ -155,4 +155,5 @@ echo "${projectConfig}" >> build.sbt
 sbt "${titleSlug}/mdoc"
 
 git add "${titleSlug}"
+git add build.sbt
 git commit -m "${title}, first commit"


### PR DESCRIPTION
## Description

This PR adds a convenience script for creating new presentations. It can be invoked as:

```
nix-shell --run './scripts/new-presentation "A punchy title"'
```

The actions it will perform are:

- creating the directory to host the presentation
- initializing an `index.html` in that directory with some example slides with different scala code fences
- copying the remark minified js
- adding an sbt module pointing to that directory
- checking out a branch reflecting the presentation title
- committing the setup

### Checklist

not applicable, not a new presentation